### PR TITLE
Switch from JSDOM to Cheerio

### DIFF
--- a/lib/get-server-url.js
+++ b/lib/get-server-url.js
@@ -20,7 +20,7 @@ function findUrlFromBody(body, callback) {
       callbackFired = false;
 
   $('link').each(function(idx, el) {
-    if (relIsWebmentionMatch(el.attribs.rel)) {
+    if (el.attribs.rel && relIsWebmentionMatch(el.attribs.rel)) {
       callback(null, el.attribs.href);
       callbackFired = true;
       return;

--- a/lib/get-server-url.js
+++ b/lib/get-server-url.js
@@ -1,4 +1,4 @@
-var jsdom = require('jsdom');
+var cheerio = require('cheerio');
 
 function getServerUrl(linkHeaders, body, callback) {
   var url = findUrlFromLinkHeaders(linkHeaders);
@@ -16,34 +16,15 @@ function findUrlFromLinkHeaders(linkHeaders) {
 }
 
 function findUrlFromBody(body, callback) {
-  var params = {
-    html: body,
-    scripts: [],
-    done: function (err, window) {
-      var linkElements;
-      var l;
-
-      if (err) {
-        callback(err);
-      }
-      else {
-        linkElements = window.document.getElementsByTagName('link');
-
-        for (l in linkElements) {
-          if (linkElements.hasOwnProperty(l)) {
-            if (relIsWebmentionMatch(linkElements[l].getAttribute('rel'))) {
-              callback(null, linkElements[l].getAttribute('href'));
-              return;
-            }
-          }
-        }
-
-        callback();
-      }
+  var $ = cheerio.load(body);
+  $('link').each(function(idx, el) {
+    if (relIsWebmentionMatch(el.attribs.rel)) {
+      callback(null, el.attribs.href);
+      return;
     }
-  };
+  });
 
-  jsdom.env(params);
+  callback();
 }
 
 function relIsWebmentionMatch(rel) {

--- a/lib/get-server-url.js
+++ b/lib/get-server-url.js
@@ -16,15 +16,18 @@ function findUrlFromLinkHeaders(linkHeaders) {
 }
 
 function findUrlFromBody(body, callback) {
-  var $ = cheerio.load(body);
+  var $ = cheerio.load(body),
+      callbackFired = false;
+
   $('link').each(function(idx, el) {
     if (relIsWebmentionMatch(el.attribs.rel)) {
       callback(null, el.attribs.href);
+      callbackFired = true;
       return;
     }
   });
 
-  callback();
+  if (!callbackFired) callback();
 }
 
 function relIsWebmentionMatch(rel) {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "tape": "~1.0.4"
   },
   "dependencies": {
-    "request": "~2.22.0",
-    "jsdom": "~0.7.0"
+    "cheerio": "^1.0.0-rc.2",
+    "request": "~2.22.0"
   }
 }


### PR DESCRIPTION
There are numerous reasons to do this:

* JSDOM does not sandbox the JavaScript it runs; as such this was insecurely running potentially untrusted code
* Cheerio is (according to its README) 8x faster
* The implementation is simpler
* The module now works on modern Node.js versions - before it would fail because the super old version of JSDOM we used pulled in the `contextify` module

This change is technically semver-major because webpages that fill in their endpoints with JavaScript won't work anymore. But honestly, there's no way anyone's doing that in the wild.

Note that tests are failing on my machine... pushing this to see if Travis disagrees.