### PR TITLE
[WIP] Fix a crash if <link>s don't have a rel= attribute defined

### DIFF
--- a/lib/get-server-url.js
+++ b/lib/get-server-url.js
@@ -1,4 +1,4 @@
-var jsdom = require('jsdom');
+var cheerio = require('cheerio');
 
 function getServerUrl(linkHeaders, body, callback) {
   var url = findUrlFromLinkHeaders(linkHeaders);
@@ -16,34 +16,15 @@ function findUrlFromLinkHeaders(linkHeaders) {
 }
 
 function findUrlFromBody(body, callback) {
-  var params = {
-    html: body,
-    scripts: [],
-    done: function (err, window) {
-      var linkElements;
-      var l;
-
-      if (err) {
-        callback(err);
-      }
-      else {
-        linkElements = window.document.getElementsByTagName('link');
-
-        for (l in linkElements) {
-          if (linkElements.hasOwnProperty(l)) {
-            if (relIsWebmentionMatch(linkElements[l].getAttribute('rel'))) {
-              callback(null, linkElements[l].getAttribute('href'));
-              return;
-            }
-          }
-        }
-
-        callback();
-      }
+  var $ = cheerio.load(body);
+  $('link').each(function(idx, el) {
+    if (relIsWebmentionMatch(el.attribs.rel)) {
+      callback(null, el.attribs.href);
+      return;
     }
-  };
+  });
 
-  jsdom.env(params);
+  callback();
 }
 
 function relIsWebmentionMatch(rel) {

--- a/lib/get-server-url.js
+++ b/lib/get-server-url.js
@@ -18,7 +18,7 @@ function findUrlFromLinkHeaders(linkHeaders) {
 function findUrlFromBody(body, callback) {
   var $ = cheerio.load(body);
   $('link').each(function(idx, el) {
-    if (relIsWebmentionMatch(el.attribs.rel)) {
+    if (el.attribs.rel && relIsWebmentionMatch(el.attribs.rel)) {
       callback(null, el.attribs.href);
       return;
     }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "tape": "~1.0.4"
   },
   "dependencies": {
-    "request": "~2.22.0",
-    "jsdom": "~0.7.0"
+    "cheerio": "^1.0.0-rc.2",
+    "request": "~2.22.0"
   }
 }


### PR DESCRIPTION
```
/home/alex/Development/lazymention/node_modules/lookup-webmention-server/lib/get-server-url.js:34
  return rel.match(/^webmention$/) || rel.match(/^http:\/\/webmention\.org/);
            ^

TypeError: Cannot read property 'match' of undefined
    at relIsWebmentionMatch (/home/alex/Development/lazymention/node_modules/lookup-webmention-server/lib/get-server-url.js:34:13)
    at Node.<anonymous> (/home/alex/Development/lazymention/node_modules/lookup-webmention-server/lib/get-server-url.js:23:9)
    at initialize.exports.each (/home/alex/Development/lazymention/node_modules/cheerio/lib/api/traversing.js:300:24)
    at findUrlFromBody (/home/alex/Development/lazymention/node_modules/lookup-webmention-server/lib/get-server-url.js:22:13)
    at getServerUrl (/home/alex/Development/lazymention/node_modules/lookup-webmention-server/lib/get-server-url.js:10:5)
    at LookupWebmentionServer._httpResponse (/home/alex/Development/lazymention/node_modules/lookup-webmention-server/index.js:26:5)
    at Request.self.callback (/home/alex/Development/lazymention/node_modules/lookup-webmention-server/node_modules/request/request.js:186:22)
    at emitTwo (events.js:125:13)
    at Request.emit (events.js:213:7)
    at Request.<anonymous> (/home/alex/Development/lazymention/node_modules/lookup-webmention-server/node_modules/request/request.js:1163:10)
    at emitOne (events.js:115:13)
    at Request.emit (events.js:210:7)
    at IncomingMessage.<anonymous> (/home/alex/Development/lazymention/node_modules/lookup-webmention-server/node_modules/request/request.js:1085:12)
    at Object.onceWrapper (events.js:314:30)
    at emitNone (events.js:110:20)
    at IncomingMessage.emit (events.js:207:7)
```

I think? I need to actually test this.